### PR TITLE
Small tweaks to configure store function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 import expect from 'expect';
 import { applyMiddleware } from 'redux';
 
-export default function configureStore(middlewares) {
+export default function configureStore(middlewares = []) {
 
   return function mockStore(getState, expectedActions, done) {
-    if (!Array.isArray(expectedActions)) {
-      throw new Error('expectedActions should be an array of expected actions.');
+    if (!expectedActions) {
+      throw new Error('expectedActions should be an expected action or an array of actions.');
+    } else if (!Array.isArray(expectedActions)) {
+      expectedActions = [expectedActions]
     }
 
     if (typeof done !== 'undefined' && typeof done !== 'function') {
@@ -30,7 +32,11 @@ export default function configureStore(middlewares) {
             }
             return action;
           } catch (e) {
-            done(e);
+            if (done) {
+              done(e);  
+            } else {
+              throw e;
+            }
           }
         }
       };

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default function configureStore(middlewares = []) {
     }
 
     function mockStoreWithoutMiddleware() {
-      return {
+      const self = {
         getState() {
           return typeof getState === 'function' ?
             getState() :
@@ -23,6 +23,10 @@ export default function configureStore(middlewares = []) {
         },
 
         dispatch(action) {
+          if (action instanceof Function) {
+            return action(self)
+          }
+
           const expectedAction = expectedActions.shift();
 
           try {
@@ -40,6 +44,8 @@ export default function configureStore(middlewares = []) {
           }
         }
       };
+
+      return self;
     }
 
     const mockStoreWithMiddleware = applyMiddleware(

--- a/test/index.js
+++ b/test/index.js
@@ -7,9 +7,15 @@ const mockStore = configureStore([]);
 
 describe('Redux mockStore', () => {
 
-  it('throws an error if expectedActions is not an array', () => {
-    expect(() => mockStore({}, {}))
+  it('throws an error if expectedActions is not provided', () => {
+    expect(() => mockStore({}))
     .toThrow(/expectedActions/);
+  });
+
+  it('converts a single expected action to an array', () => {
+    const store = mockStore({}, {});
+
+    expect(store).toExist();
   });
 
   it('throws an error if done is not a function or undefined', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,18 @@ describe('Redux mockStore', () => {
     );
   });
 
+  it('handles async actions', done => {
+    const clock = sinon.useFakeTimers();
+    const action = async ({ dispatch }) => {
+      const value = await Promise.resolve({ type: 'ASYNC' })
+      dispatch(value)
+    };
+    const store = mockStore({}, [{ type: 'ASYNC' }], done);
+    store.dispatch(action);
+    clock.tick(1);
+    clock.restore();
+  });
+
   it('should call the middleware', (done) => {
     const spy = sinon.spy();
     const middlewares = [mockMiddleware(spy)];

--- a/test/index.js
+++ b/test/index.js
@@ -51,6 +51,15 @@ describe('Redux mockStore', () => {
     store.dispatch(action);
   });
 
+  it('handles actions that return functions', () => {
+    const action = { type: 'ADD_ITEM' };
+    const store = mockStore({}, [action]);
+
+    store.dispatch(
+      ({ dispatch }) => dispatch(action)
+    );
+  });
+
   it('should call the middleware', (done) => {
     const spy = sinon.spy();
     const middlewares = [mockMiddleware(spy)];


### PR DESCRIPTION
Couple of minor suggestions for easier usability:
- Default `middlewares` parameter to an empty array if not specified
- Allow `expectedActions` param to be either an array or an object; auto-convert to an array if an object is specified (test added)
- Make sure `done` is not null before calling in `catch` statement. Otherwise this will hide the actual error and instead throw an error about `done` not being a function
- Handles actions that return async or sync functions (test added).
