### PR TITLE
Custom test function instead of expected action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ it('should dispatch action', (done) => {
 })
 ```
 
+Custom test function for actions can also be supplied, useful if your actions have a dynamic
+part.
+
+```js
+// Test in mocha
+it('should dispatch action', (done) => {
+  const getState = {}; // initial state of the store
+  const action = { type: 'ADD_TODO' };
+  const expectedActions = [(incomingAction) => {
+    if (incomingAction.type !== 'ADD_TODO') {
+      throw Error('Expected action of type ADD_TODO');
+    }
+  }];
+
+  const store = mockStore(getState, expectedActions, done);
+  store.dispatch(action);
+})
+```
+
 ## License
 
 MIT

--- a/src/index.js
+++ b/src/index.js
@@ -30,14 +30,18 @@ export default function configureStore(middlewares = []) {
           const expectedAction = expectedActions.shift();
 
           try {
-            expect(action).toEqual(expectedAction);
+            if (typeof expectedAction === 'function') {
+              expectedAction(action);
+            } else {
+              expect(action).toEqual(expectedAction);
+            }
             if (done && !expectedActions.length) {
               done();
             }
             return action;
           } catch (e) {
             if (done) {
-              done(e);  
+              done(e);
             } else {
               throw e;
             }

--- a/test/index.js
+++ b/test/index.js
@@ -85,11 +85,19 @@ describe('Redux mockStore', () => {
 
   it('should use test function instead of matching action if supplied', (done) => {
     const action = { type: 'ADD_ITEM' };
-    const store = mockStore({}, [(a) => {
-      expect(a).toBe(action);
-    }], done);
+    const action2 = { type: 'SET_TIMESTAMP', stamp: Date.now() };
+    const action3 = { type: 'DELETE_ITEM' };
+    const store = mockStore({}, [
+      action,
+      (a) => {
+        expect(a.type).toBe('SET_TIMESTAMP');
+      },
+      action3
+    ], done);
 
     store.dispatch(action);
+    store.dispatch(action2);
+    store.dispatch(action3);
   });
 
   it('should handle when test function throws an error', (done) => {

--- a/test/index.js
+++ b/test/index.js
@@ -82,4 +82,28 @@ describe('Redux mockStore', () => {
     store.dispatch(action);
     expect(spy.called).toBe(true);
   });
+
+  it('should use test function instead of matching action if supplied', (done) => {
+    const action = { type: 'ADD_ITEM' };
+    const store = mockStore({}, [(a) => {
+      expect(a).toBe(action);
+    }], done);
+
+    store.dispatch(action);
+  });
+
+  it('should handle when test function throws an error', (done) => {
+    const action = { type: 'ADD_ITEM' };
+    const store = mockStore({}, [(incomingAction) => {
+      if (incomingAction.type !== 'ADD_TODO') {
+        throw Error('Expected action of type ADD_TODO');
+      }
+    }], (err) => {
+      expect(err).toExist();
+      expect(err.message).toBe('Expected action of type ADD_TODO');
+      done();
+    });
+
+    store.dispatch(action);
+  });
 });


### PR DESCRIPTION
Hi, 

this is a PR for a small tweak that I needed, and I was 
hoping you might find it useful.

If a function is supplied instead of an expected action
then that function is called with the incoming action
as an argument. This is useful when your action creators 
adds a dynamic part to the action object, like a time stamp
or some such.

The supplied "test function" should throw an error if the 
action doesn't match what it expects. 
