### PR TITLE
Ensure expectedActions is not mutated by using a copy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,9 @@ export default function configureStore(middlewares = []) {
     if (!expectedActions) {
       throw new Error('expectedActions should be an expected action or an array of actions.');
     } else if (!Array.isArray(expectedActions)) {
-      expectedActions = [expectedActions]
+      expectedActions = [expectedActions];
+    } else {
+      expectedActions = Array.prototype.slice.call(expectedActions);
     }
 
     if (typeof done !== 'undefined' && typeof done !== 'function') {

--- a/test/index.js
+++ b/test/index.js
@@ -94,4 +94,12 @@ describe('Redux mockStore', () => {
       done();
     }
   });
+
+  it('does not modify the expectedActions when dispatching', () => {
+    let expectedActions = [{ type: 'ADD_ITEM' }, { type: 'REMOVE_ITEM' }];
+    const store = mockStore({}, expectedActions);
+    store.dispatch({ type: 'ADD_ITEM' });
+    store.dispatch({ type: 'REMOVE_ITEM' });
+    expect(expectedActions.length).toEqual(2);
+  });
 });


### PR DESCRIPTION
In the current implementation the `expectedActions` array passed to `mockStore(…)` cannot be reused, because it will be modified by the calls to `.shift()`.

This PR proposes to use a copy of `expectedActions` so that we do not mess around with the users variables.

---

In the following use case the second `it()` will fail because meanwhile `expectedActions` has changed. This PR would fix the issue.

```
var expectedActions = [{ type: 'FOO' }, { type: 'BAR' }];

it('does something', function() {
  // 1) all good
  const store = createMockStore({ order: {} }, expectedActions, done);
  store.dispatch(action);
});

it('does another thing', function() {
  // 2) expectedActions is empty now :(
  const store = createMockStore({ order: {} }, expectedActions, done);
  store.dispatch(action);
});
```
