### PR TITLE
Redux should be a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   "devDependencies": {
     "babel": "^5.8.29",
     "mocha": "^2.3.3",
-    "redux": "^3.0.4",
     "rimraf": "^2.4.3",
     "sinon": "^1.17.2"
   },
   "dependencies": {
+    "redux": "^3.0.4",
     "expect": "^1.12.2"
   }
 }


### PR DESCRIPTION
Redux should be defined as a regular dependency; otherwise, one might run into
`Error: Cannot find module 'redux'` when importing `configureStore` from `redux-mock-store` if the package into which it's imported doesn't have `redux` set (and installed) as a dependency.

[This Stack Overflow answer](http://stackoverflow.com/a/22004559) provides more details regarding npm dependencies.
