### PR TITLE
Accommodate Jasmine's done.fail(e)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,11 @@ export default function configureStore(middlewares = []) {
             return action;
           } catch (e) {
             if (done) {
-              done(e);
+              if (isFunction(done.fail)) {
+                done.fail(e);
+              } else {
+                done(e);
+              }
             }
             throw e;
           }


### PR DESCRIPTION
Should be able to call `done.fail(e)` if function fail exists, in the case of Jasmine. 

Related to #16 and #12
