### PR TITLE
Fix Mocha example to work with broken tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ it('should execute promise', (done) => {
     store.dispatch(fetchData())
       .then(() => {
         expect(store.getActions()[0]).toEqual(success())
-        done();
-      });
+      }).then(done).catch(done);
 })
 ```
 


### PR DESCRIPTION
Using the existing example, Mocha will never call done() if the test fails resulting with the same error found in https://github.com/arnaudbenard/redux-mock-store/issues/30.
