### PR TITLE
Return promise from store.dispatch(action)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ logs
 *.log
 node_modules
 lib
+.idea/

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export default function configureStore(middlewares=[]) {
         dispatch(action) {
           actions.push(action);
 
-          return action;
+          return Promise.resolve(action);
         },
 
         clearActions() {

--- a/test/index.js
+++ b/test/index.js
@@ -34,7 +34,6 @@ describe('redux-mock-store', () => {
     expect(first).toBe(action);
   });
 
-
   it('handles async actions', (done) => {
     function increment() {
       return {
@@ -56,6 +55,28 @@ describe('redux-mock-store', () => {
         expect(store.getActions()[0]).toEqual(increment())
         done();
       });
+  });
+
+  it('handles thunk actions', (done) => {
+    function increment() {
+      return {
+        type: 'INCREMENT_COUNTER'
+      };
+    }
+
+    function incrementAsync() {
+      return dispatch => {
+        return dispatch(increment());
+      };
+    }
+    const store = mockStore({});
+
+    store.dispatch(incrementAsync())
+      .then(() => {
+        expect(store.getActions().length).toEqual(1)
+        expect(store.getActions()[0]).toEqual(increment())
+      })
+      .then(done);
   });
 
   it('should call the middleware', () => {


### PR DESCRIPTION
Fixes #31, redux-thunk compatibility

I'm using this in my project now and everything is working for me, however I would like to see others try it out as well.

I don't know how breaking it is returning a promise resolving to the action instead of the action itself, or if it might break other middleware. Thoughts?
