### PR TITLE
Update Mocha promise example to return promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ it('should dispatch action', () => {
 });
 
 // Promise test example with mocha and expect
-it('should execute promise', (done) => {
+it('should execute promise', () => {
     function success() {
       return {
         type: 'FETCH_DATA_SUCCESS'
@@ -56,10 +56,11 @@ it('should execute promise', (done) => {
 
     const store = mockStore({});
 
-    store.dispatch(fetchData())
+    // Return the promise
+    return store.dispatch(fetchData())
       .then(() => {
         expect(store.getActions()[0]).toEqual(success())
-      }).then(done).catch(done);
+      });
 })
 ```
 


### PR DESCRIPTION
Instead of using the done() callback, you may return a promise.
See https://mochajs.org/#working-with-promises
