### PR TITLE
Add store subscribe functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export default function configureStore(middlewares=[]) {
   return function mockStore(getState={}) {
     function mockStoreWithoutMiddleware() {
       let actions = [];
+      let listeners = [];
 
       const self = {
         getState() {
@@ -19,6 +20,10 @@ export default function configureStore(middlewares=[]) {
 
         dispatch(action) {
           actions.push(action);
+          
+          for (let i = 0; i < listeners.length; i++) {
+            listeners[i]();
+          }
 
           return action;
         },
@@ -27,7 +32,10 @@ export default function configureStore(middlewares=[]) {
           actions = [];
         },
 
-        subscribe() {
+        subscribe(cb) {
+          if (isFunction(cb)) {
+            listeners.push(cb);
+          }
           return null;
         }
       };

--- a/test/index.js
+++ b/test/index.js
@@ -104,9 +104,14 @@ describe('redux-mock-store', () => {
     expect(store.getActions()).toEqual(actions);
   });
 
-  it('has empty subscribe method', () => {
+  it('subscribes to dispatched actions', (done) => {
     const store = mockStore();
-
-    expect(store.subscribe()).toEqual(null);
+    const action = { type: 'ADD_ITEM' };
+    
+    store.subscribe(() => {
+      expect(store.getActions()[0]).toEqual(action);
+      done();
+    });
+    store.dispatch(action);
   });
 });


### PR DESCRIPTION
I added store subscribe functionality to allow thunk-actions to be tested easily (see the modified test). This resolves some of the issues raised in #31. 
