### PR TITLE
Add check to dispatcher for undefined action and undefined action type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,19 @@ export default function configureStore(middlewares=[]) {
         },
 
         dispatch(action) {
+          if (typeof action === 'undefined') {
+            throw new Error(
+              'Actions may not be an undefined.'
+            );
+          }
+
+          if (typeof action.type === 'undefined') {
+            throw new Error(
+              'Actions may not have an undefined "type" property. ' +
+              'Have you misspelled a constant?'
+            );
+          }
+
           actions.push(action);
           
           for (let i = 0; i < listeners.length; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,24 @@ describe('redux-mock-store', () => {
     expect(store.getState()).toEqual(initialState);
   });
 
+   it('should throw an error when action is undefined', () => {
+    const store = mockStore({});
+
+    expect(() => { store.dispatch(undefined); }).toThrow(
+      'Actions may not be an undefined.'
+    );
+  });
+
+  it('should throw an error when action type is undefined', () => {
+    const action = { types: 'ADD_ITEM' };
+    const store = mockStore({});
+
+    expect(() => { store.dispatch(action); }).toThrow(
+      'Actions may not have an undefined "type" property. ' +
+      'Have you misspelled a constant?'
+    );
+  });
+
   it('should return if the tests is successful', () => {
     const action = { type: 'ADD_ITEM' };
     const store = mockStore({});


### PR DESCRIPTION
In our team, we've been facing issues when we've misspelled action export or action type, and as a result - tests was passing but the application was failing.

Took them from redux's dispatcher method https://github.com/reactjs/redux/blob/master/src/createStore.js#L157-L162

What do you think about adding such checks into dispatcher?
I'm ok if, you don't want to overcomplicate your library with that kind of stuff.
