### PR TITLE
Fixed definitions so they resolve as external modules properly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ logs
 *.log
 node_modules
 lib
+.idea/

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,17 +8,15 @@
 // Usage:
 // const mockStore = configureStore();
 
-declare module "redux-mock-store" {
-    import {Store} from 'redux';
+import {Store, Middleware, Unsubscribe} from 'redux';
 
-    interface MockStore extends Store {
-        getState(): any;
-        getActions(): Array<any>;
-        dispatch(action: any): any;
-        clearActions(): void;
-        subscribe(): any;
-    }
-
-    function configureStore(...args: any[]) : (...args: any[]) => MockStore;
-    export = configureStore;
+interface MockStore<S> extends Store<S> {
+    getState():S;
+    getActions():Array<any>;
+    dispatch(action:any):any;
+    clearActions():void;
+    subscribe(listener: Function):Unsubscribe;
 }
+
+declare function configureStore<S>(...middlewares:any[]):(...args:any[]) => MockStore<S>;
+export = configureStore;


### PR DESCRIPTION
Not 100% sure this is the absolute best way to go around this, but it seems to work for now.
