### PR TITLE
fix d.ts based on pull request comments (it was missing)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,15 +8,15 @@
 // Usage:
 // const mockStore = configureStore();
 
-import {Store, Middleware, Unsubscribe} from 'redux';
+import {Store} from 'redux';
 
-interface MockStore<S> extends Store<S> {
-    getState():S;
+interface MockStore extends Store {
+    getState():any;
     getActions():Array<any>;
     dispatch(action:any):any;
     clearActions():void;
-    subscribe(listener: Function):Unsubscribe;
+    subscribe():any;
 }
 
-declare function configureStore<S>(...middlewares:any[]):(...args:any[]) => MockStore<S>;
+declare function configureStore(...args:any[]):(...args:any[]) => MockStore;
 export = configureStore;


### PR DESCRIPTION
Just realized, 

In the previous PR we merged the wrong version of the d.ts definitions:

[https://github.com/arnaudbenard/redux-mock-store/issues/39](https://github.com/arnaudbenard/redux-mock-store/issues/39)

The right version was the one commented by @asgarddesigns  but by mistake we merged the one in the PR.

```
import {Store} from 'redux';

interface MockStore extends Store {
    getState():any;
    getActions():Array<any>;
    dispatch(action:any):any;
    clearActions():void;
    subscribe():any;
}

declare function configureStore(...args:any[]):(...args:any[]) => MockStore;
export = configureStore;

```

In this fork you can find the fix (gong to add it to a new issue I have created).
