### PR TITLE
Add type param to State to satisfy the definition of State<T> in redux

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@
 
 import {Store} from 'redux';
 
-interface MockStore extends Store {
+interface MockStore extends Store<any> {
     getState():any;
     getActions():Array<any>;
     dispatch(action:any):any;


### PR DESCRIPTION
I get an error that State is missing a required type param.  I'm using the following versions.  This fixes it for me.
"redux": "^3.5.2",
"redux-thunk": "^2.1.0",
