### PR TITLE
Update TypeScript type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@
 
 import {Store} from 'redux';
 
-interface MockStore extends Store {
+interface MockStore<StoreState> extends Store<StoreState> {
     getState():any;
     getActions():Array<any>;
     dispatch(action:any):any;
@@ -18,5 +18,5 @@ interface MockStore extends Store {
     subscribe():any;
 }
 
-declare function configureStore(...args:any[]):(...args:any[]) => MockStore;
+declare function configureStore<StoreState>(...args:any[]):(...args:any[]) => MockStore<StoreState>;
 export = configureStore;


### PR DESCRIPTION
Recently, the `index.d.ts` type definition inside the latest version of
`redux` has changed. The `Store` type now has a type variable `S` for
the store state. However, the `Store` variable inside the `index.d.ts`
file of `redux-mock-store` still doesn't reflect this change and causes
compilation errors when used alongside `redux`'s latest type definition.

This omission is fixed in this pull request.
