### PR TITLE
Add circle.yml config to manage NodeJS version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 4.5.0


### PR DESCRIPTION
- Use new version of NodeJS on CI during PR checks.(Used current LTS version 4.5.0)

Related: https://github.com/arnaudbenard/redux-mock-store/pull/61
