### PR TITLE
Add a setState method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ it('should execute promise', () => {
 - mockStore(getState?: Object,Function) => store: Function
 - store.dispatch(action) => action
 - store.getState() => state: Object
+- store.setState(getState?: Object,Function)
 - store.getActions() => actions: Array
 - store.clearActions()
 - store.subscribe()

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ import {Store} from 'redux';
 
 interface MockStore extends Store {
     getState():any;
+    setState(getState:any):void;
     getActions():Array<any>;
     dispatch(action:any):any;
     clearActions():void;

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,25 @@ const isFunction = arg => typeof arg === 'function'
 
 export default function configureStore (middlewares = []) {
   return function mockStore (getState = {}) {
+    let state = getState
+
     function mockStoreWithoutMiddleware () {
       let actions = []
       let listeners = []
 
+      const executeListeners = () => {
+        for (let i = 0; i < listeners.length; i++) {
+          listeners[i]()
+        }
+      }
       const self = {
         getState () {
-          return isFunction(getState) ? getState() : getState
+          return isFunction(state) ? state() : state
+        },
+
+        setState (getState) {
+          state = getState
+          executeListeners()
         },
 
         getActions () {
@@ -35,9 +47,7 @@ export default function configureStore (middlewares = []) {
 
           actions.push(action)
 
-          for (let i = 0; i < listeners.length; i++) {
-            listeners[i]()
-          }
+          executeListeners()
 
           return action
         },

--- a/test/index.js
+++ b/test/index.js
@@ -152,4 +152,31 @@ describe('redux-mock-store', () => {
     unsubscribe();
     store.dispatch(action);
   });
+
+  it('updates the state', function () {
+    const initialState = Symbol();
+    const store = mockStore(initialState);
+
+    expect(store.getState()).toEqual(initialState);
+
+    const getState = Symbol();
+    store.setState(getState);
+
+    expect(store.getState()).toEqual(getState);
+  });
+
+  it('updating the state dispatches subscribers', function () {
+    const store = mockStore();
+    const listeners = [
+      sinon.spy(),
+      sinon.spy(),
+      sinon.spy()
+    ];
+
+    listeners.forEach(listener => store.subscribe(listener));
+
+    store.setState(Symbol());
+
+    listeners.forEach(listener => expect(listener.calledOnce).toBe(true))
+  });
 });


### PR DESCRIPTION
I am interested in adding a `setState` method that will dispatch the subscribers. My main motivation is to be able to test changes to the state on connected react components in redux without having to create fake reducers and actions.
