### PR TITLE
Add replaceReducer function and apply standard to tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ it('should execute promise', () => {
 - store.getActions() => actions: Array
 - store.clearActions()
 - store.subscribe()
+- store.replaceReducer()
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "rimraf lib && babel src --out-dir lib",
-    "lint": "standard src/*.js",
+    "lint": "standard src/*.js test/*.js",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,11 @@ export default function configureStore (middlewares = []) {
             }
             listeners.splice(index, 1)
           }
+        },
+        replaceReducer (nextReducer) {
+          if (!isFunction(nextReducer)) {
+            throw new Error('Expected the nextReducer to be a function.')
+          }
         }
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -152,4 +152,16 @@ describe('redux-mock-store', () => {
     unsubscribe();
     store.dispatch(action);
   });
+
+
+  it('has replace reducer function', () => {
+    const action = { type: 'ADD_ITEM' };
+    const store = mockStore({});
+
+    expect(()=>store.replaceReducer(()=>{}))
+    .toNotThrow('Expected the nextReducer to be a function.');
+    
+    expect(()=>store.replaceReducer(123))
+    .toThrow('Expected the nextReducer to be a function.');
+  })
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,167 +1,164 @@
-import expect from 'expect';
-import sinon from 'sinon';
-import thunk from 'redux-thunk';
+/* eslint-env mocha */
+import expect from 'expect'
+import sinon from 'sinon'
+import thunk from 'redux-thunk'
 
-import mockMiddleware from './mock/middleware';
-import configureStore from '../src';
+import mockMiddleware from './mock/middleware'
+import configureStore from '../src'
 
-const mockStore = configureStore([thunk]);
+const mockStore = configureStore([thunk])
 
 describe('redux-mock-store', () => {
-
   it('calls getState if it is a function', () => {
-    const getState = sinon.spy();
-    const store = mockStore(getState, []);
+    const getState = sinon.spy()
+    const store = mockStore(getState, [])
 
-    store.getState();
-    expect(getState.called).toBe(true);
-  });
+    store.getState()
+    expect(getState.called).toBe(true)
+  })
 
   it('returns the initial state', () => {
-    const initialState = { items: [], count: 0 };
-    const store = mockStore(initialState);
+    const initialState = { items: [], count: 0 }
+    const store = mockStore(initialState)
 
-    expect(store.getState()).toEqual(initialState);
-  });
+    expect(store.getState()).toEqual(initialState)
+  })
 
-   it('should throw an error when action is undefined', () => {
-    const store = mockStore({});
+  it('should throw an error when action is undefined', () => {
+    const store = mockStore({})
 
-    expect(() => { store.dispatch(undefined); }).toThrow(
+    expect(() => { store.dispatch(undefined) }).toThrow(
       'Actions may not be an undefined.'
-    );
-  });
+    )
+  })
 
   it('should throw an error when action type is undefined', () => {
-    const action = { types: 'ADD_ITEM' };
-    const store = mockStore({});
+    const action = { types: 'ADD_ITEM' }
+    const store = mockStore({})
 
-    expect(() => { store.dispatch(action); }).toThrow(
+    expect(() => { store.dispatch(action) }).toThrow(
       'Actions may not have an undefined "type" property. ' +
-      'Have you misspelled a constant? '+
+      'Have you misspelled a constant? ' +
       'Action: ' +
       '{"types":"ADD_ITEM"}'
-    );
-  });
+    )
+  })
 
   it('should return if the tests is successful', () => {
-    const action = { type: 'ADD_ITEM' };
-    const store = mockStore({});
+    const action = { type: 'ADD_ITEM' }
+    const store = mockStore({})
 
-    store.dispatch(action);
+    store.dispatch(action)
 
-    const [first] = store.getActions();
-    expect(first).toBe(action);
-  });
-
+    const [first] = store.getActions()
+    expect(first).toBe(action)
+  })
 
   it('handles async actions', (done) => {
-    function increment() {
+    function increment () {
       return {
         type: 'INCREMENT_COUNTER'
-      };
+      }
     }
 
-    function incrementAsync() {
+    function incrementAsync () {
       return dispatch => {
         return Promise.resolve()
-          .then(() => dispatch(increment()));
-      };
+          .then(() => dispatch(increment()))
+      }
     }
 
-    const store = mockStore({});
+    const store = mockStore({})
 
     store.dispatch(incrementAsync())
       .then(() => {
         expect(store.getActions()[0]).toEqual(increment())
-        done();
-      });
-  });
+        done()
+      })
+  })
 
   it('should call the middleware', () => {
-    const spy = sinon.spy();
-    const middlewares = [mockMiddleware(spy)];
-    const mockStoreWithMiddleware = configureStore(middlewares);
-    const action = { type: 'ADD_ITEM' };
+    const spy = sinon.spy()
+    const middlewares = [mockMiddleware(spy)]
+    const mockStoreWithMiddleware = configureStore(middlewares)
+    const action = { type: 'ADD_ITEM' }
 
-    const store = mockStoreWithMiddleware();
-    store.dispatch(action);
-    expect(spy.called).toBe(true);
-  });
+    const store = mockStoreWithMiddleware()
+    store.dispatch(action)
+    expect(spy.called).toBe(true)
+  })
 
   it('should handle when test function throws an error', (done) => {
-    const store = mockStore({});
-    const error = { error: 'Something went wrong' };
+    const store = mockStore({})
+    const error = { error: 'Something went wrong' }
 
     store.dispatch(() => Promise.reject(error))
       .catch(err => {
-        expect(err).toEqual(error);
-        done();
+        expect(err).toEqual(error)
+        done()
       })
-  });
+  })
 
   it('clears the actions', () => {
-    const action = { type: 'ADD_ITEM' };
-    const store = mockStore({});
+    const action = { type: 'ADD_ITEM' }
+    const store = mockStore({})
 
-    store.dispatch(action);
-    expect(store.getActions()).toEqual([action]);
+    store.dispatch(action)
+    expect(store.getActions()).toEqual([action])
 
-    store.clearActions();
-    expect(store.getActions()).toEqual([]);
+    store.clearActions()
+    expect(store.getActions()).toEqual([])
   })
 
   it('handles multiple actions', () => {
-    const store = mockStore();
+    const store = mockStore()
     const actions = [
       { type: 'ADD_ITEM' },
       { type: 'REMOVE_ITEM' }
-    ];
+    ]
 
-    store.dispatch(actions[0]);
-    store.dispatch(actions[1]);
+    store.dispatch(actions[0])
+    store.dispatch(actions[1])
 
-    expect(store.getActions()).toEqual(actions);
-  });
+    expect(store.getActions()).toEqual(actions)
+  })
 
   it('subscribes to dispatched actions', (done) => {
-    const store = mockStore();
-    const action = { type: 'ADD_ITEM' };
+    const store = mockStore()
+    const action = { type: 'ADD_ITEM' }
 
     store.subscribe(() => {
-      expect(store.getActions()[0]).toEqual(action);
-      done();
-    });
-    store.dispatch(action);
-  });
+      expect(store.getActions()[0]).toEqual(action)
+      done()
+    })
+    store.dispatch(action)
+  })
 
   it('can unsubscribe subscribers', function (done) {
-    const store = mockStore();
-    const action = { type: 'ADD_ITEM' };
-    const waitForMS = 25;
-    const testWaitsAnotherMS = 25;
+    const store = mockStore()
+    const action = { type: 'ADD_ITEM' }
+    const waitForMS = 25
+    const testWaitsAnotherMS = 25
 
-    this.timeout(waitForMS + testWaitsAnotherMS);
-    const timeoutId = setTimeout(done, waitForMS);
+    this.timeout(waitForMS + testWaitsAnotherMS)
+    const timeoutId = setTimeout(done, waitForMS)
 
     const unsubscribe = store.subscribe(() => {
-      clearTimeout(timeoutId);
-      done(new Error('should never be called'));
-    });
+      clearTimeout(timeoutId)
+      done(new Error('should never be called'))
+    })
 
-    unsubscribe();
-    store.dispatch(action);
-  });
-
+    unsubscribe()
+    store.dispatch(action)
+  })
 
   it('has replace reducer function', () => {
-    const action = { type: 'ADD_ITEM' };
-    const store = mockStore({});
+    const store = mockStore({})
 
-    expect(()=>store.replaceReducer(()=>{}))
-    .toNotThrow('Expected the nextReducer to be a function.');
-    
-    expect(()=>store.replaceReducer(123))
-    .toThrow('Expected the nextReducer to be a function.');
+    expect(() => store.replaceReducer(() => {}))
+      .toNotThrow('Expected the nextReducer to be a function.')
+
+    expect(() => store.replaceReducer(123))
+      .toThrow('Expected the nextReducer to be a function.')
   })
-});
+})

--- a/test/mock/middleware.js
+++ b/test/mock/middleware.js
@@ -1,4 +1,4 @@
 export default spy => store => next => action => {
-  spy();
-  return next(action);
-};
+  spy()
+  return next(action)
+}


### PR DESCRIPTION
- Add replaceReducer function according to [redux source code](https://github.com/reactjs/redux/blob/8e82c15f1288a0a5c5c886ffd87e7e73dc0103e1/src/createStore.js#L194-L201)
- Apply standard to tests

Not sure if it should dispatch `'@@redux/INIT'` function as redux does.
But store creation doesn't dispatch it so probably here it is also not needed.

Resolves #74 
