### PR TITLE
Clean up test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,7 @@ const mockStore = configureStore([thunk])
 describe('redux-mock-store', () => {
   it('calls getState if it is a function', () => {
     const getState = sinon.spy()
-    const store = mockStore(getState, [])
+    const store = mockStore(getState)
 
     store.getState()
     expect(getState.called).toBe(true)


### PR DESCRIPTION
Remove unused second argument to mockStore() call.

Closes #100.