### PR TITLE
Add umd build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,13 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    [
+      "es2015",
+      {
+        "modules": false
+      }
+    ]
+  ],
+  "plugins": [
+    "external-helpers"
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ logs
 *.log
 node_modules
 lib
+dist
 .idea/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
-src
 .babelrc
+src
+test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "A mock store for testing your redux async action creators and middleware",
   "main": "lib/index.js",
   "scripts": {
-    "prepublish": "rimraf lib && babel src --out-dir lib",
+    "prepublish": "rimraf lib && rimraf dist && npm run build",
+    "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
+    "build:umd": "cross-env BABEL_ENV=es NODE_ENV=development rollup -c -i src/index.js -o dist/redux-mock-store.js",
+    "build:umd:min": "cross-env BABEL_ENV=es NODE_ENV=production rollup -c -i src/index.js -o dist/redux-mock-store.min.js",
+    "build": "npm run build:commonjs && npm run build:umd && npm run build:umd:min",
     "lint": "standard src/*.js test/*.js",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js"
@@ -22,12 +26,19 @@
   "devDependencies": {
     "babel-cli": "^6.11.4",
     "babel-core": "^6.13.2",
-    "babel-preset-es2015": "^6.13.2",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-preset-es2015": "^6.24.1",
+    "cross-env": "^5.0.1",
     "expect": "^1.12.2",
     "mocha": "^2.3.3",
     "redux": "^3.0.4",
     "redux-thunk": "^2.0.1",
     "rimraf": "^2.4.3",
+    "rollup": "^0.45.1",
+    "rollup-plugin-babel": "^2.7.1",
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^1.1.1",
+    "rollup-plugin-uglify": "^2.0.1",
     "sinon": "^1.17.2",
     "standard": "^7.1.2"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,36 @@
+import nodeResolve from 'rollup-plugin-node-resolve';
+import babel from 'rollup-plugin-babel';
+import replace from 'rollup-plugin-replace';
+import uglify from 'rollup-plugin-uglify';
+
+var env = process.env.NODE_ENV
+var config = {
+  format: 'umd',
+  moduleName: 'ReduxMockStore',
+  plugins: [
+    nodeResolve({
+      jsnext: true
+    }),
+    babel({
+      exclude: 'node_modules/**'
+    }),
+    replace({
+      'process.env.NODE_ENV': JSON.stringify(env)
+    })
+  ]
+}
+
+if (env === 'production') {
+  config.plugins.push(
+    uglify({
+      compress: {
+        pure_getters: true,
+        unsafe: true,
+        unsafe_comps: true,
+        warnings: false
+      }
+    })
+  )
+}
+
+export default config


### PR DESCRIPTION
UMD build implementation.
Adds dist/ folder with redux-mock-store.js and redux-mock-store.min.js
The library is accessible via window.ReduxMockStore
Build will appear here after publish: https://unpkg.com/redux-mock-store@latest/

Can, please, anyone test it?

Resolves #107 
Resolves #90