### PR TITLE
conform more to basic redux behavior for dispatch.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "rimraf lib && babel src --out-dir lib",
-    "lint": "standard src/*.js test/*.js --fix",
+    "lint": "standard src/*.js test/*.js",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "rimraf lib && babel src --out-dir lib",
-    "lint": "standard src/*.js test/*.js",
+    "lint": "standard src/*.js test/*.js --fix",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js"
   },
@@ -30,5 +30,8 @@
     "rimraf": "^2.4.3",
     "sinon": "^1.17.2",
     "standard": "^7.1.2"
+  },
+  "dependencies": {
+    "lodash.isplainobject": "^4.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-mock-store",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A mock store for testing your redux async action creators and middleware",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { applyMiddleware } from 'redux'
+import isPlainObject from 'lodash.isplainobject'
 
 const isFunction = arg => typeof arg === 'function'
 
@@ -18,9 +19,10 @@ export default function configureStore (middlewares = []) {
         },
 
         dispatch (action) {
-          if (typeof action === 'undefined') {
+          if (!isPlainObject(action)) {
             throw new Error(
-              'Actions may not be an undefined.'
+              'Actions must be plain objects. ' +
+              'Use custom middleware for async actions.'
             )
           }
 


### PR DESCRIPTION
Hi! Thanks for creating this project! 😄 

I updated redux-mock-store to conform more to the `store.dispatch` method by using the same lodash.isPlainObject check from: https://github.com/reactjs/redux/blob/master/src/createStore.js#L150

This also helps users catch themselves if they accidentally pass in an thunk without configuring the store with the thunk middleware for example. I also updated the tests and added the "--fix" to the lint script. 

Please let me know if these changes are fine. Or if I should change anything. Thank You!
