### PR TITLE
Redux should be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   },
   "dependencies": {
     "lodash.isplainobject": "^4.0.6"
+  },
+  "peerDependencies": {
+    "redux": "*"
   }
 }


### PR DESCRIPTION
This makes sure the dependency graph is not broken when installing dependencies, and warns the user when installing the package without `redux` aside.

See #20 for more information.