### PR TITLE
Make CommonJS Version backwards compatible and Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ npm install redux-mock-store --save-dev
 The simplest usecase is for the synchronous actions. In this example, we will test if the `addTodo` action returns the right payload. `redux-mock-store` saves all the dispatched actions inside the store instance. You can get all the action by calling `store.getActions()`. Finally, you can use any assertion library to test the payload.
 
 ```js
-import configureStore from 'redux-mock-store'
+import configureStore from 'redux-mock-store' //ES6 modules
+const { configureStore } = require('redux-mock-store') //CommonJS
 
 const middlewares = []
 const mockStore = configureStore(middlewares)
@@ -125,6 +126,13 @@ Follows the redux API
 
 https://github.com/arnaudbenard/redux-mock-store/blob/v0.0.6/README.md
 
+### Versions
+
+The following versions are exposed by redux-mock-store from the `package.json`:
+
+* `main`: commonJS Version
+* `module`/`js:next`: ES Module Version
+* `browser` : UMD version
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "browser": "dist/index.min.js",
   "scripts": {
     "prepublish": "rimraf lib && rimraf dist && npm run build",
-    "build:cjs": "cross-env BABEL_ENV=es NODE_ENV=production rollup -f cjs -c -i src/index.js -o dist/index-cjs.js",
+    "build:cjs": "babel src --out-file dist/index-cjs.js",
     "build:umd": "cross-env BABEL_ENV=es NODE_ENV=development rollup -f umd -c -i src/index.js -o dist/index-umd.js",
     "build:umd:min": "cross-env BABEL_ENV=es NODE_ENV=production rollup -f umd -c -i src/index.js -o dist/index-umd.min.js",
     "build:es": "cross-env BABEL_ENV=es NODE_ENV=development rollup -f es -c -i src/index.js -o dist/index-es.js",
-    "build": "npm run build:cjs && npm run build:umd && npm run build:umd:min && npm run build:es",
+    "build": "npm run build:umd && npm run build:umd:min && npm run build:es && npm run build:cjs",
     "lint": "standard src/*.js test/*.js",
     "pretest": "npm run lint",
     "test": "mocha --compilers js:babel-core/register --reporter spec test/*.js"

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import isPlainObject from 'lodash.isplainobject'
 
 const isFunction = arg => typeof arg === 'function'
 
-export default function configureStore (middlewares = []) {
+export function configureStore (middlewares = []) {
   return function mockStore (getState = {}) {
     function mockStoreWithoutMiddleware () {
       let actions = []
@@ -80,3 +80,5 @@ export default function configureStore (middlewares = []) {
     return mockStoreWithMiddleware()
   }
 }
+
+export default configureStore


### PR DESCRIPTION
The previous version of the CommonJS build actually broke backwards compatibility because it stopped exporting `configureStore` as `exports.default`. 

This is fixed in this PR by having a named and default export and reverting back to Babel to create the  commonJS version.

This means that this way still works: 
```js
const configureStore = require('redux-mock-store').default;
```
And this way also works:
```js
const reduxMockStore = require('redux-mock-store');

const mockStore = reduxMockStore.configureStore(middlewares);
```
or
```js
const { configureStore } = require('redux-mock-store');
```

Which means with Babel the following also still works using the commonJS version:

```js
import configureStore from 'redux-mock-store';
```

I have also updated the docs to reflect this change.

@dmitry-zaets Can you test this before we merge it for me? And then I think it would be a good idea to deprecate the previous versions that are giving people trouble (1.5.0 and 1.5.1).

Fixes #135