### PR TITLE
Add deprecation notice to README and JSDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ it("should add a todo", () => {
 });
 ```
 
-This avoids common pitfalls of testing each of these in isolation, such as state shape becoming out of sync with the actual application.
+This avoids common pitfalls of testing each of these in isolation, such as mocked state shape becoming out of sync with the actual application.
 
 # redux-mock-store [![Circle CI](https://circleci.com/gh/arnaudbenard/redux-mock-store/tree/master.svg?style=svg)](https://circleci.com/gh/arnaudbenard/redux-mock-store/tree/master)
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Testing with a mock store leads to potentially confusing behaviour, such as stat
 You can test the entire combination of action creators, reducers, and selectors in a single test, for example:
 
 ```js
-it("should add a todo", () => {
-  const store = makeStore(); // a user defined reusable store factory
+it('should add a todo', () => {
+  const store = makeStore() // a user defined reusable store factory
 
-  store.dispatch(addTodo("Use Redux"));
+  store.dispatch(addTodo('Use Redux'))
 
   expect(selectTodos(store.getState())).toEqual([
-    { text: "Use Redux", completed: false },
-  ]);
-});
+    { text: 'Use Redux', completed: false }
+  ])
+})
 ```
 
 This avoids common pitfalls of testing each of these in isolation, such as mocked state shape becoming out of sync with the actual application.
@@ -47,28 +47,28 @@ yarn add redux-mock-store --dev
 The simplest usecase is for synchronous actions. In this example, we will test if the `addTodo` action returns the right payload. `redux-mock-store` saves all the dispatched actions inside the store instance. You can get all the actions by calling `store.getActions()`. Finally, you can use any assertion library to test the payload.
 
 ```js
-import configureStore from "redux-mock-store"; //ES6 modules
-const { configureStore } = require("redux-mock-store"); //CommonJS
+import configureStore from 'redux-mock-store' //ES6 modules
+const { configureStore } = require('redux-mock-store') //CommonJS
 
-const middlewares = [];
-const mockStore = configureStore(middlewares);
+const middlewares = []
+const mockStore = configureStore(middlewares)
 
 // You would import the action from your codebase in a real scenario
-const addTodo = () => ({ type: "ADD_TODO" });
+const addTodo = () => ({ type: 'ADD_TODO' })
 
-it("should dispatch action", () => {
+it('should dispatch action', () => {
   // Initialize mockstore with empty state
-  const initialState = {};
-  const store = mockStore(initialState);
+  const initialState = {}
+  const store = mockStore(initialState)
 
   // Dispatch the action
-  store.dispatch(addTodo());
+  store.dispatch(addTodo())
 
   // Test if your store dispatched the expected actions
-  const actions = store.getActions();
-  const expectedPayload = { type: "ADD_TODO" };
-  expect(actions).toEqual([expectedPayload]);
-});
+  const actions = store.getActions()
+  const expectedPayload = { type: 'ADD_TODO' }
+  expect(actions).toEqual([expectedPayload])
+})
 ```
 
 ### Asynchronous actions
@@ -76,35 +76,35 @@ it("should dispatch action", () => {
 A common usecase for an asynchronous action is a HTTP request to a server. In order to test those types of actions, you will need to call `store.getActions()` at the end of the request.
 
 ```js
-import configureStore from "redux-mock-store";
-import thunk from "redux-thunk";
+import configureStore from 'redux-mock-store'
+import thunk from 'redux-thunk'
 
-const middlewares = [thunk]; // add your middlewares like `redux-thunk`
-const mockStore = configureStore(middlewares);
+const middlewares = [thunk] // add your middlewares like `redux-thunk`
+const mockStore = configureStore(middlewares)
 
 // You would import the action from your codebase in a real scenario
 function success() {
   return {
-    type: "FETCH_DATA_SUCCESS",
-  };
+    type: 'FETCH_DATA_SUCCESS'
+  }
 }
 
 function fetchData() {
   return (dispatch) => {
-    return fetch("/users.json") // Some async action with promise
-      .then(() => dispatch(success()));
-  };
+    return fetch('/users.json') // Some async action with promise
+      .then(() => dispatch(success()))
+  }
 }
 
-it("should execute fetch data", () => {
-  const store = mockStore({});
+it('should execute fetch data', () => {
+  const store = mockStore({})
 
   // Return the promise
   return store.dispatch(fetchData()).then(() => {
-    const actions = store.getActions();
-    expect(actions[0]).toEqual(success());
-  });
-});
+    const actions = store.getActions()
+    expect(actions[0]).toEqual(success())
+  })
+})
 ```
 
 ### API
@@ -140,7 +140,7 @@ store.getActions() => actions: Array
 Returns the actions of the mock store.
 
 ```js
-store.clearActions();
+store.clearActions()
 ```
 
 Clears the stored actions.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
-# redux-mock-store [![Circle CI](https://circleci.com/gh/arnaudbenard/redux-mock-store/tree/master.svg?style=svg)](https://circleci.com/gh/arnaudbenard/redux-mock-store/tree/master)
+# Deprecation notice
 
+The Redux team does not recommend testing using this library. Instead, see our [docs](https://redux.js.org/usage/writing-tests) for recommended practices, using a real store.
+
+Testing with a mock store leads to potentially confusing behaviour, such as state not updating when actions are dispatched. Additionally, it's a lot less useful to assert on the actions dispatched rather than the observable state changes.
+
+You can test the entire combination of action creators, reducers, and selectors in a single test, for example:
+
+```js
+it("should add a todo", () => {
+  const store = makeStore(); // a user defined reusable store factory
+
+  store.dispatch(addTodo("Use Redux"));
+
+  expect(selectTodos(store.getState())).toEqual([
+    { text: "Use Redux", completed: false },
+  ]);
+});
+```
+
+This avoids common pitfalls of testing each of these in isolation, such as state shape becoming out of sync with the actual application.
+
+# redux-mock-store [![Circle CI](https://circleci.com/gh/arnaudbenard/redux-mock-store/tree/master.svg?style=svg)](https://circleci.com/gh/arnaudbenard/redux-mock-store/tree/master)
 
 ![npm](https://nodei.co/npm/redux-mock-store.png?downloads=true&downloadRank=true&stars=true)
 
@@ -26,29 +47,28 @@ yarn add redux-mock-store --dev
 The simplest usecase is for synchronous actions. In this example, we will test if the `addTodo` action returns the right payload. `redux-mock-store` saves all the dispatched actions inside the store instance. You can get all the actions by calling `store.getActions()`. Finally, you can use any assertion library to test the payload.
 
 ```js
-import configureStore from 'redux-mock-store' //ES6 modules
-const { configureStore } = require('redux-mock-store') //CommonJS
+import configureStore from "redux-mock-store"; //ES6 modules
+const { configureStore } = require("redux-mock-store"); //CommonJS
 
-const middlewares = []
-const mockStore = configureStore(middlewares)
+const middlewares = [];
+const mockStore = configureStore(middlewares);
 
 // You would import the action from your codebase in a real scenario
-const addTodo = () => ({ type: 'ADD_TODO' })
+const addTodo = () => ({ type: "ADD_TODO" });
 
-it('should dispatch action', () => {
-
+it("should dispatch action", () => {
   // Initialize mockstore with empty state
-  const initialState = {}
-  const store = mockStore(initialState)
+  const initialState = {};
+  const store = mockStore(initialState);
 
   // Dispatch the action
-  store.dispatch(addTodo())
+  store.dispatch(addTodo());
 
   // Test if your store dispatched the expected actions
-  const actions = store.getActions()
-  const expectedPayload = { type: 'ADD_TODO' }
-  expect(actions).toEqual([expectedPayload])
-})
+  const actions = store.getActions();
+  const expectedPayload = { type: "ADD_TODO" };
+  expect(actions).toEqual([expectedPayload]);
+});
 ```
 
 ### Asynchronous actions
@@ -56,36 +76,35 @@ it('should dispatch action', () => {
 A common usecase for an asynchronous action is a HTTP request to a server. In order to test those types of actions, you will need to call `store.getActions()` at the end of the request.
 
 ```js
-import configureStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
+import configureStore from "redux-mock-store";
+import thunk from "redux-thunk";
 
-const middlewares = [thunk] // add your middlewares like `redux-thunk`
-const mockStore = configureStore(middlewares)
+const middlewares = [thunk]; // add your middlewares like `redux-thunk`
+const mockStore = configureStore(middlewares);
 
 // You would import the action from your codebase in a real scenario
 function success() {
   return {
-    type: 'FETCH_DATA_SUCCESS'
-  }
-}
-
-function fetchData () {
-  return dispatch => {
-    return fetch('/users.json') // Some async action with promise
-      .then(() => dispatch(success()))
+    type: "FETCH_DATA_SUCCESS",
   };
 }
 
-it('should execute fetch data', () => {
-  const store = mockStore({})
+function fetchData() {
+  return (dispatch) => {
+    return fetch("/users.json") // Some async action with promise
+      .then(() => dispatch(success()));
+  };
+}
+
+it("should execute fetch data", () => {
+  const store = mockStore({});
 
   // Return the promise
-  return store.dispatch(fetchData())
-    .then(() => {
-      const actions = store.getActions()
-      expect(actions[0]).toEqual(success())
-    })
-})
+  return store.dispatch(fetchData()).then(() => {
+    const actions = store.getActions();
+    expect(actions[0]).toEqual(success());
+  });
+});
 ```
 
 ### API
@@ -93,41 +112,49 @@ it('should execute fetch data', () => {
 ```js
 configureStore(middlewares?: Array) => mockStore: Function
 ```
+
 Configure mock store by applying the middlewares.
 
 ```js
 mockStore(getState?: Object,Function) => store: Function
 ```
+
 Returns an instance of the configured mock store. If you want to reset your store after every test, you should call this function.
 
 ```js
 store.dispatch(action) => action
 ```
+
 Dispatches an action through the mock store. The action will be stored in an array inside the instance and executed.
 
 ```js
 store.getState() => state: Object
 ```
+
 Returns the state of the mock store.
 
 ```js
 store.getActions() => actions: Array
 ```
+
 Returns the actions of the mock store.
 
 ```js
-store.clearActions()
+store.clearActions();
 ```
+
 Clears the stored actions.
 
 ```js
 store.subscribe(callback: Function) => unsubscribe: Function
 ```
+
 Subscribe to the store.
 
 ```js
 store.replaceReducer(nextReducer: Function)
 ```
+
 Follows the Redux API.
 
 ### Old version (`< 1.x.x`)
@@ -138,9 +165,9 @@ https://github.com/arnaudbenard/redux-mock-store/blob/v0.0.6/README.md
 
 The following versions are exposed by redux-mock-store from the `package.json`:
 
-* `main`: commonJS Version
-* `module`/`js:next`: ES Module Version
-* `browser` : UMD version
+- `main`: commonJS Version
+- `module`/`js:next`: ES Module Version
+- `browser` : UMD version
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -55,5 +55,10 @@
   },
   "peerDependencies": {
     "redux": "*"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "semi": false,
+    "trailingComma": "none"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import { applyMiddleware } from "redux";
-import isPlainObject from "lodash.isplainobject";
+import { applyMiddleware } from 'redux'
+import isPlainObject from 'lodash.isplainobject'
 
-const isFunction = (arg) => typeof arg === "function";
+const isFunction = (arg) => typeof arg === 'function'
 
 /**
  * @deprecated
@@ -22,83 +22,87 @@ const isFunction = (arg) => typeof arg === "function";
  * ```
  *
  * This avoids common pitfalls of testing each of these in isolation, such as mocked state shape becoming out of sync with the actual application.
+ *
+ * If you want to use `configureStore` without this visual deprecation warning, use the `legacy_configureStore` export instead.
+ *
+ * `import { legacy_configureStore as configureStore } from 'redux-mock-store';`
  */
 export function configureStore(middlewares = []) {
   return function mockStore(getState = {}) {
     function mockStoreWithoutMiddleware() {
-      let actions = [];
-      let listeners = [];
+      let actions = []
+      let listeners = []
 
       const self = {
         getState() {
-          return isFunction(getState) ? getState(actions) : getState;
+          return isFunction(getState) ? getState(actions) : getState
         },
 
         getActions() {
-          return actions;
+          return actions
         },
 
         dispatch(action) {
           if (!isPlainObject(action)) {
             throw new Error(
-              "Actions must be plain objects. " +
-                "Use custom middleware for async actions."
-            );
+              'Actions must be plain objects. ' +
+                'Use custom middleware for async actions.'
+            )
           }
 
-          if (typeof action.type === "undefined") {
+          if (typeof action.type === 'undefined') {
             throw new Error(
               'Actions may not have an undefined "type" property. ' +
-                "Have you misspelled a constant? " +
-                "Action: " +
+                'Have you misspelled a constant? ' +
+                'Action: ' +
                 JSON.stringify(action)
-            );
+            )
           }
 
-          actions.push(action);
+          actions.push(action)
 
           for (let i = 0; i < listeners.length; i++) {
-            listeners[i]();
+            listeners[i]()
           }
 
-          return action;
+          return action
         },
 
         clearActions() {
-          actions = [];
+          actions = []
         },
 
         subscribe(cb) {
           if (isFunction(cb)) {
-            listeners.push(cb);
+            listeners.push(cb)
           }
 
           return () => {
-            const index = listeners.indexOf(cb);
+            const index = listeners.indexOf(cb)
 
             if (index < 0) {
-              return;
+              return
             }
-            listeners.splice(index, 1);
-          };
+            listeners.splice(index, 1)
+          }
         },
 
         replaceReducer(nextReducer) {
           if (!isFunction(nextReducer)) {
-            throw new Error("Expected the nextReducer to be a function.");
+            throw new Error('Expected the nextReducer to be a function.')
           }
-        },
-      };
+        }
+      }
 
-      return self;
+      return self
     }
 
     const mockStoreWithMiddleware = applyMiddleware(...middlewares)(
       mockStoreWithoutMiddleware
-    );
+    )
 
-    return mockStoreWithMiddleware();
-  };
+    return mockStoreWithMiddleware()
+  }
 }
 
 /**
@@ -107,6 +111,6 @@ export function configureStore(middlewares = []) {
  *
  * @param middlewares The list of middleware to be applied.
  */
-export const legacy_configureStore = configureStore;
+export const legacy_configureStore = configureStore
 
-export default configureStore;
+export default configureStore

--- a/src/index.js
+++ b/src/index.js
@@ -1,84 +1,103 @@
-import { applyMiddleware } from 'redux'
-import isPlainObject from 'lodash.isplainobject'
+import { applyMiddleware } from "redux";
+import isPlainObject from "lodash.isplainobject";
 
-const isFunction = arg => typeof arg === 'function'
-
-export function configureStore (middlewares = []) {
-  return function mockStore (getState = {}) {
-    function mockStoreWithoutMiddleware () {
-      let actions = []
-      let listeners = []
+const isFunction = (arg) => typeof arg === "function";
+/**
+ * @deprecated
+ *
+ * The Redux team does not recommend using this package for testing. Instead, check out our {@link https://redux.js.org/recipes/writing-tests testing docs} to learn more about testing Redux code.
+ *
+ * Testing with a mock store leads to potentially confusing behaviour, such as state not updating when actions are dispatched. Additionally, it's a lot less useful to assert on the actions dispatched rather than the observable state changes.
+ *
+ * You can test the entire combination of action creators, reducers, and selectors in a single test, for example:
+ * ```js
+ * it("should add a todo", () => {
+ *   const store = makeStore(); // a user defined reusable store factory
+ *
+ *   store.dispatch(addTodo("Use Redux"));
+ *
+ *   expect(selectTodos(store.getState())).toEqual([{ text: "Use Redux", completed: false }]);
+ * });
+ * ```
+ *
+ * This avoids common pitfalls of testing each of these in isolation, such as mocked state shape becoming out of sync with the actual application.
+ */
+export function configureStore(middlewares = []) {
+  return function mockStore(getState = {}) {
+    function mockStoreWithoutMiddleware() {
+      let actions = [];
+      let listeners = [];
 
       const self = {
-        getState () {
-          return isFunction(getState) ? getState(actions) : getState
+        getState() {
+          return isFunction(getState) ? getState(actions) : getState;
         },
 
-        getActions () {
-          return actions
+        getActions() {
+          return actions;
         },
 
-        dispatch (action) {
+        dispatch(action) {
           if (!isPlainObject(action)) {
             throw new Error(
-              'Actions must be plain objects. ' +
-              'Use custom middleware for async actions.'
-            )
+              "Actions must be plain objects. " +
+                "Use custom middleware for async actions."
+            );
           }
 
-          if (typeof action.type === 'undefined') {
+          if (typeof action.type === "undefined") {
             throw new Error(
               'Actions may not have an undefined "type" property. ' +
-              'Have you misspelled a constant? ' +
-              'Action: ' +
-              JSON.stringify(action)
-            )
+                "Have you misspelled a constant? " +
+                "Action: " +
+                JSON.stringify(action)
+            );
           }
 
-          actions.push(action)
+          actions.push(action);
 
           for (let i = 0; i < listeners.length; i++) {
-            listeners[i]()
+            listeners[i]();
           }
 
-          return action
+          return action;
         },
 
-        clearActions () {
-          actions = []
+        clearActions() {
+          actions = [];
         },
 
-        subscribe (cb) {
+        subscribe(cb) {
           if (isFunction(cb)) {
-            listeners.push(cb)
+            listeners.push(cb);
           }
 
           return () => {
-            const index = listeners.indexOf(cb)
+            const index = listeners.indexOf(cb);
 
             if (index < 0) {
-              return
+              return;
             }
-            listeners.splice(index, 1)
-          }
+            listeners.splice(index, 1);
+          };
         },
 
-        replaceReducer (nextReducer) {
+        replaceReducer(nextReducer) {
           if (!isFunction(nextReducer)) {
-            throw new Error('Expected the nextReducer to be a function.')
+            throw new Error("Expected the nextReducer to be a function.");
           }
-        }
-      }
+        },
+      };
 
-      return self
+      return self;
     }
 
-    const mockStoreWithMiddleware = applyMiddleware(
-      ...middlewares
-    )(mockStoreWithoutMiddleware)
+    const mockStoreWithMiddleware = applyMiddleware(...middlewares)(
+      mockStoreWithoutMiddleware
+    );
 
-    return mockStoreWithMiddleware()
-  }
+    return mockStoreWithMiddleware();
+  };
 }
 
-export default configureStore
+export default configureStore;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { applyMiddleware } from "redux";
 import isPlainObject from "lodash.isplainobject";
 
 const isFunction = (arg) => typeof arg === "function";
+
 /**
  * @deprecated
  *
@@ -99,5 +100,13 @@ export function configureStore(middlewares = []) {
     return mockStoreWithMiddleware();
   };
 }
+
+/**
+ * Create Mock Store returns a function that will create a mock store from a state
+ * with the supplied set of middleware applied.
+ *
+ * @param middlewares The list of middleware to be applied.
+ */
+export const legacy_configureStore = configureStore;
 
 export default configureStore;


### PR DESCRIPTION
fixes #183

Redux Mock Store still has a lot of usage in the ecosystem, but the Redux team believes there are better approaches to testing a store. Similar to our [deprecation of createStore](https://github.com/reduxjs/redux/issues/4325), deprecating this package/function will reach people who may not have seen our updated testing guidance.

A `legacy_configureStore` export without the deprecation notice is available.

The JSDoc will also need updating over on the [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/redux-mock-store) side, but we'll do that once we've agreed how to do it here.